### PR TITLE
Fix: Agregar middleware faltante

### DIFF
--- a/src/express.ts
+++ b/src/express.ts
@@ -11,6 +11,7 @@ import swaggerConfig from './config/swagger.config';
 
 const app = express();
 
+app.use(express.json());
 app.use(cors());
 app.use(helmet());
 


### PR DESCRIPTION
# Fix: Agregar middleware faltante

closes #29 

## Cambios
Se agregó el middleware que faltaba (`express.json`)