### PR TITLE
Fix: Hacer que los errores en la sintaxis del JSON devuelvan un codigo de estado 400

### DIFF
--- a/src/express.ts
+++ b/src/express.ts
@@ -12,6 +12,7 @@ import fallbackErrorTransformer from './middlewares/fallback-error-transformer.m
 import logger from './logger';
 import requestLogger from './middlewares/request-logger.middleware';
 import swaggerConfig from './config/swagger.config';
+import syntaxErrorHandler from './middlewares/syntax-error-handler.middleware';
 
 const app = express();
 
@@ -30,6 +31,8 @@ routes.forEach((route) => {
   app.use(route.getBasePath(), route.getRouter());
   logger.info(`Routes configured for ${route.getBasePath()}`);
 });
+
+app.use(syntaxErrorHandler);
 
 app.use(errorLogger);
 

--- a/src/middlewares/syntax-error-handler.middleware.ts
+++ b/src/middlewares/syntax-error-handler.middleware.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from 'express';
+import HttpError from '../errors/http.error';
+import HttpStatus from '../models/enums/http-status.enum';
+
+/**
+ * Sends an `HttpError` with a 400 status code to the next error handler when the request body receives malformed JSON.
+ */
+export default function syntaxErrorHandler(
+  err: Error,
+  _req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  if (err instanceof SyntaxError) {
+    return next(new HttpError(HttpStatus.BAD_REQUEST, err.message));
+  }
+
+  return next(err);
+}


### PR DESCRIPTION
closes #30 

Ahora los errores en la sintaxis del JSON devuelven un codigo de estado 400 con el detalle del error, en vez de un codigo 500.
![image](https://user-images.githubusercontent.com/58740322/167075652-87943a61-5c7d-4873-86d3-6f354af9d7fa.png)
