### PR TITLE
Simplificar los mensajes de validación

### DIFF
--- a/src/middlewares/validate-body.middleware.ts
+++ b/src/middlewares/validate-body.middleware.ts
@@ -24,6 +24,7 @@ export default function validateBody(
   ) {
     const toValidate = plainToInstance(c, req.body ?? {}, {
       exposeUnsetFields: false,
+      excludeExtraneousValues: true,
     });
 
     const validationErrors = await validate(toValidate, { whitelist });
@@ -31,7 +32,9 @@ export default function validateBody(
     if (validationErrors.length > 0) {
       const error = new HttpError(HttpStatus.BAD_REQUEST, {
         description: 'Validation error.',
-        errors: validationErrors,
+        errors: validationErrors.flatMap((err) =>
+          Object.values(err.constraints as Record<string, string>),
+        ),
       });
       return next(error);
     }


### PR DESCRIPTION
# Simplificar los mansajes de validación

Closes #35 

## Cambios introducidos

- **Los mensajes de validacion se muestran como en el ejemplo de la issue**
- Se agrego la opción `excludeExtraneousValues: true` al transformador de objetos

## Notas

Ahora se tiene que agregar el decorador `@Expose()` importado desde `class-transformer` a cada propiedad de los DTO.