### PR TITLE
Ocultar las propiedades `null`

### DIFF
--- a/src/controllers/characters.controller.ts
+++ b/src/controllers/characters.controller.ts
@@ -1,3 +1,4 @@
+import { instanceToPlain } from 'class-transformer';
 import { Request, Response, NextFunction } from 'express';
 import { Service } from 'typedi';
 import HttpError from '../errors/http.error';
@@ -17,9 +18,11 @@ export default class CharactersController {
     next: NextFunction,
   ): Promise<Response | void> {
     try {
+      const result = await this.service.findAll(req.query);
+
       return res
         .status(HttpStatus.OK)
-        .json(await this.service.findAll(req.query));
+        .json(instanceToPlain(result, { excludeExtraneousValues: true }));
     } catch (err) {
       return next(err);
     }
@@ -37,7 +40,9 @@ export default class CharactersController {
       const character = await this.service.findOne(Number(req.params.id));
 
       if (character) {
-        return res.status(HttpStatus.OK).json(character);
+        return res
+          .status(HttpStatus.OK)
+          .json(instanceToPlain(character, { excludeExtraneousValues: true }));
       }
 
       return next(new HttpError(HttpStatus.NOT_FOUND, 'Character not found.'));

--- a/src/decorators/hide-null.decorator.ts
+++ b/src/decorators/hide-null.decorator.ts
@@ -1,0 +1,10 @@
+import { Transform } from 'class-transformer';
+
+/**
+ * Converts `null` properties to `undefined` when transforming to a plain object
+ */
+export default function HideNull() {
+  return Transform(({ value }) => (value !== null ? value : undefined), {
+    toPlainOnly: true,
+  });
+}

--- a/src/models/character.model.ts
+++ b/src/models/character.model.ts
@@ -1,3 +1,4 @@
+import { Expose, Type } from 'class-transformer';
 import { col, fn } from 'sequelize';
 import {
   BelongsToMany,
@@ -7,6 +8,7 @@ import {
   AllowNull,
   Table,
 } from 'sequelize-typescript';
+import HideNull from '../decorators/hide-null.decorator';
 import MovieCharacter from './movie-character.model';
 import Movie from './movie.model';
 
@@ -26,10 +28,23 @@ import Movie from './movie.model';
 })
 export default class Character extends Model {
   /**
+   * Character's unique id.
+   * @example 1
+   */
+  @Expose()
+  @Column({
+    primaryKey: true,
+    autoIncrement: true,
+    autoIncrementIdentity: true,
+  })
+  id!: number;
+
+  /**
    * Character's name.
    *
    * @example 'Simba'
    */
+  @Expose()
   @AllowNull(false)
   @Column(DataType.STRING(30))
   name!: string;
@@ -39,18 +54,24 @@ export default class Character extends Model {
    *
    * @example 'https://upload.wikimedia.org/wikipedia/en/9/94/Simba_%28_Disney_character_-_adult%29.png'
    */
+  @Expose()
+  @HideNull()
   @Column(DataType.STRING(2048))
   imageUrl!: string | null;
 
   /**
    * Character's age, in years.
    */
+  @Expose()
+  @HideNull()
   @Column(DataType.INTEGER)
   age!: number | null;
 
   /**
    * Character's weight, in kilograms.
    */
+  @Expose()
+  @HideNull()
   @Column(DataType.INTEGER)
   weight!: number | null;
 
@@ -58,12 +79,16 @@ export default class Character extends Model {
    * Character's backstory and/or a summary of the character's involvement in the
    * productions they took part of.
    */
+  @Expose()
+  @HideNull()
   @Column(DataType.STRING(1000))
   history!: string | null;
 
   /**
    * List of movies that the character participated on.
    */
+  @Expose()
+  @Type(() => Movie)
   @BelongsToMany(() => Movie, () => MovieCharacter)
   movies!: Movie[];
 }

--- a/src/models/genre.model.ts
+++ b/src/models/genre.model.ts
@@ -1,3 +1,4 @@
+import { Expose, Type } from 'class-transformer';
 import { col, fn } from 'sequelize';
 import {
   Column,
@@ -7,6 +8,7 @@ import {
   AllowNull,
   Table,
 } from 'sequelize-typescript';
+import HideNull from '../decorators/hide-null.decorator';
 import Movie from './movie.model';
 
 /**
@@ -25,10 +27,23 @@ import Movie from './movie.model';
 })
 export default class Genre extends Model {
   /**
+   * Genre's unique id.
+   * @example 1
+   */
+  @Expose()
+  @Column({
+    primaryKey: true,
+    autoIncrement: true,
+    autoIncrementIdentity: true,
+  })
+  id!: number;
+
+  /**
    * Name of the genre.
    *
    * @example 'Drama'
    */
+  @Expose()
   @AllowNull(false)
   @Column(DataType.STRING(30))
   name!: string;
@@ -38,12 +53,16 @@ export default class Genre extends Model {
    *
    * @example 'https://upload.wikimedia.org/wikipedia/commons/1/10/Drama_Masks.svg'
    */
+  @Expose()
+  @HideNull()
   @Column(DataType.STRING(2048))
   imageUrl!: string | null;
 
   /**
    * List of movies that belong to the genre.
    */
+  @Expose()
+  @Type(() => Movie)
   @HasMany(() => Movie)
   movies!: Movie[];
 }

--- a/src/models/movie.model.ts
+++ b/src/models/movie.model.ts
@@ -1,3 +1,4 @@
+import { Expose, Exclude, Type } from 'class-transformer';
 import { col, fn } from 'sequelize';
 import {
   BelongsTo,
@@ -10,6 +11,7 @@ import {
   AllowNull,
   Table,
 } from 'sequelize-typescript';
+import HideNull from '../decorators/hide-null.decorator';
 import Character from './character.model';
 import Genre from './genre.model';
 import MovieCharacter from './movie-character.model';
@@ -30,10 +32,23 @@ import MovieCharacter from './movie-character.model';
 })
 export default class Movie extends Model {
   /**
+   * Movie's unique id.
+   * @example 1
+   */
+  @Expose()
+  @Column({
+    primaryKey: true,
+    autoIncrement: true,
+    autoIncrementIdentity: true,
+  })
+  id!: number;
+
+  /**
    * Title of the movie.
    *
    * @example 'The Lion King'
    */
+  @Expose()
   @AllowNull(false)
   @Column(DataType.STRING(100))
   title!: string;
@@ -43,6 +58,8 @@ export default class Movie extends Model {
    *
    * @example 'https://upload.wikimedia.org/wikipedia/en/3/3d/The_Lion_King_poster.jpg'
    */
+  @Expose()
+  @HideNull()
   @Column(DataType.STRING(2048))
   imageUrl!: string | null;
 
@@ -51,6 +68,7 @@ export default class Movie extends Model {
    *
    * @example 1
    */
+  @Exclude({ toPlainOnly: true })
   @ForeignKey(() => Genre)
   @AllowNull(false)
   @Column
@@ -59,6 +77,7 @@ export default class Movie extends Model {
   /**
    * Genre of the movie.
    */
+  @Expose()
   @BelongsTo(() => Genre)
   genre!: Genre;
 
@@ -70,6 +89,8 @@ export default class Movie extends Model {
    *
    * @example 4.7
    */
+  @Expose()
+  @HideNull()
   @Column(DataType.DECIMAL(2, 1))
   rating!: number | null;
 
@@ -78,12 +99,15 @@ export default class Movie extends Model {
    *
    * @example '2022-04-23T02:17:57.207Z'
    */
+  @Expose()
   @CreatedAt
   createdAt!: Date;
 
   /**
    * List of characters of the movie.
    */
+  @Expose()
+  @Type(() => Character)
   @BelongsToMany(() => Character, () => MovieCharacter)
   characters!: Character[];
 }


### PR DESCRIPTION
# Ocultar las propiedades `null` 

closes #39 

## Cambios introducidos

Ahora cuando en la base de datos hay una propiedad null, no se devuelve en el json de la respuesta.

## Ejemplos

No se devuelven la propiedad `age`, ni `weight`
![image](https://user-images.githubusercontent.com/58740322/167509804-d38c5190-dc16-4675-b2bc-5f786605e8d1.png)

No se devuelve la propiedad `imageUrl`
![image](https://user-images.githubusercontent.com/58740322/167509885-f731381d-0448-45d9-a271-5e8e472d1e28.png) 