### PR TITLE
Limitar cantidad de personajes eliminados

### DIFF
--- a/src/controllers/services/characters.service.ts
+++ b/src/controllers/services/characters.service.ts
@@ -74,6 +74,6 @@ export default class CharactersService {
    * @returns The number of deleted characters (0 or 1).
    */
   delete(id: number): Promise<number> {
-    return Character.destroy({ where: { id } });
+    return Character.destroy({ where: { id }, limit: 1 });
   }
 }


### PR DESCRIPTION
# Limitar cantidad de personajes eliminados

closes #45 

## Cambios introducidos

Se agregó una propiedad `limit` al método `Character.destroy` en `CharactersService.delete`