### PR TITLE
Fix: La aplicación no arranca en configuración de debug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,13 @@ async function bootstrap() {
     if (appConfig.ENVIRONMENT !== 'production') {
       await db.sync({ force: true });
 
-      spawn('npx sequelize db:seed:all', { shell: true });
+      let command = 'npx sequelize db:seed:all';
+
+      if (appConfig.ENVIRONMENT === 'debug') {
+        command += ' --debug';
+      }
+
+      spawn(command, { shell: true });
     }
 
     logger.info('Database connected.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata';
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { spawn } from 'child_process';
 import { config } from 'dotenv';
 import { Sequelize } from 'sequelize-typescript';
 
@@ -18,7 +17,8 @@ async function bootstrap() {
 
     if (appConfig.ENVIRONMENT !== 'production') {
       await db.sync({ force: true });
-      await promisify(exec)('npx sequelize db:seed:all');
+
+      spawn('npx sequelize db:seed:all', { shell: true });
     }
 
     logger.info('Database connected.');


### PR DESCRIPTION
# Fix: La aplicación no arranca en configuración de debug

closes #49

## Cambios introducidos

- Se usa el método `spawn` en vez de  `exec` para que la aplicación no crashee en modo debug
- Se agregó el parámetro `--debug` al seeder cuando la aplicación se ejecuta con dicha configuración.  