### PR TITLE
fix: comportamiento inconsistente en los filtros de edad y peso

### DIFF
--- a/src/controllers/services/characters.service.ts
+++ b/src/controllers/services/characters.service.ts
@@ -35,7 +35,7 @@ export default class CharactersService {
         }));
 
         conditions.push({
-          [prop]: { [Op.and]: constraints },
+          [prop]: { [Op.and]: [{ [Op.not]: null }, ...constraints] },
         });
       }
     });

--- a/src/decorators/to-numeric-filter.decorator.ts
+++ b/src/decorators/to-numeric-filter.decorator.ts
@@ -1,4 +1,5 @@
 import { Transform, TransformOptions } from 'class-transformer';
+import isNumeric from 'validator/lib/isNumeric';
 import NumericFilter from '../models/types/numeric-filter.type';
 
 /**
@@ -10,8 +11,8 @@ export default function ToNumericFilter(options?: TransformOptions) {
       return value;
     }
 
-    if (!isNaN(value)) {
-      return { eq: Number(value) };
+    if (typeof value === 'string') {
+      return { eq: isNumeric(value) ? Number(value) : null };
     }
 
     // if it is an array, use first element

--- a/src/decorators/to-numeric-filter.decorator.ts
+++ b/src/decorators/to-numeric-filter.decorator.ts
@@ -19,7 +19,7 @@ export default function ToNumericFilter(options?: TransformOptions) {
     if (Array.isArray(value) && value.length > 0) {
       const [item] = value;
 
-      return { eq: !isNaN(item) ? Number(item) : null };
+      return { eq: isNumeric(item) ? Number(item) : null };
     }
 
     const result: NumericFilter = {};
@@ -35,7 +35,7 @@ export default function ToNumericFilter(options?: TransformOptions) {
           val = val[0];
         }
 
-        result[key] = !isNaN(val) ? Number(val) : null;
+        result[key] = isNumeric(val) ? Number(val) : null;
       }
     });
 

--- a/src/decorators/to-numeric-filter.decorator.ts
+++ b/src/decorators/to-numeric-filter.decorator.ts
@@ -19,7 +19,9 @@ export default function ToNumericFilter(options?: TransformOptions) {
     if (Array.isArray(value) && value.length > 0) {
       const [item] = value;
 
-      return { eq: isNumeric(item) ? Number(item) : null };
+      return {
+        eq: typeof item === 'string' && isNumeric(item) ? Number(item) : null,
+      };
     }
 
     const result: NumericFilter = {};
@@ -35,7 +37,8 @@ export default function ToNumericFilter(options?: TransformOptions) {
           val = val[0];
         }
 
-        result[key] = isNumeric(val) ? Number(val) : null;
+        result[key] =
+          typeof val === 'string' && isNumeric(val) ? Number(val) : null;
       }
     });
 

--- a/src/models/dto/characters/filter-character.dto.ts
+++ b/src/models/dto/characters/filter-character.dto.ts
@@ -1,5 +1,6 @@
 import { Expose, Transform } from 'class-transformer';
 import { IsOptional } from 'class-validator';
+import isNumeric from 'validator/lib/isNumeric';
 import NormalizeQueryParamString from '../../../decorators/normalize-query-param-string.decorator';
 import ToNumericFilter from '../../../decorators/to-numeric-filter.decorator';
 import Trim from '../../../decorators/trim.decorator';
@@ -34,10 +35,11 @@ export default class FilterCharacterDto extends PaginateDto {
 
     const ids: Array<number | null> = [];
 
-    return ids.concat(value).map((item: unknown) => {
-      const asNumber = Number(item);
-      return !Number.isNaN(asNumber) ? asNumber : null;
-    });
+    return ids
+      .concat(value)
+      .map((item: unknown) =>
+        typeof item === 'string' && isNumeric(item) ? Number(item) : null,
+      );
   })
   @Trim()
   movies?: Array<number | null>;

--- a/src/models/dto/movies/filter-movie.dto.ts
+++ b/src/models/dto/movies/filter-movie.dto.ts
@@ -1,5 +1,6 @@
 import { Expose, Transform } from 'class-transformer';
 import { IsOptional } from 'class-validator';
+import isNumeric from 'validator/lib/isNumeric';
 import NormalizeQueryParamString from '../../../decorators/normalize-query-param-string.decorator';
 import Trim from '../../../decorators/trim.decorator';
 import PaginateDto from '../paginate.dto';
@@ -31,7 +32,7 @@ export default class FilterMovieDto extends PaginateDto {
       value = value[0];
     }
 
-    return !isNaN(value) ? Number(value) : null;
+    return typeof value === 'string' && isNumeric(value) ? Number(value) : null;
   })
   genre?: number | null;
 


### PR DESCRIPTION
# fix: comportamiento inconsistente en los filtros de edad y peso

## Cambios introducidos

- **Cuando en estos query params el parametro no es valido se devuelve un resultado vacío**
- Se cambió el uso de `!isNaN(value)` para comprobar que un valor sea numérico por `typeof value === 'string' && isNumeric(value)`

## Ejemplo

Se devuelve correctamente la lista vacía
![ejemplo](https://user-images.githubusercontent.com/58740322/168724850-e4432592-7d1e-41a3-92f7-ebb7657c83be.png)