### PR TITLE
docs: agregar query params faltantes

### DIFF
--- a/src/routes/characters.routes.ts
+++ b/src/routes/characters.routes.ts
@@ -9,6 +9,21 @@
  *       summary: Get all characters
  *       parameters:
  *         - in: query
+ *           name: page
+ *           schema:
+ *             type: integer
+ *             minimum: 1
+ *             default: 1
+ *             description: Page number of the paginated result
+ *         - in: query
+ *           name: limit
+ *           schema:
+ *             type: integer
+ *             minimum: 1
+ *             maximum: 50
+ *             default: 50
+ *             description: Maximum number of items per page
+ *         - in: query
  *           name: name
  *           schema:
  *             type: string


### PR DESCRIPTION
# Agregar query params faltantes

## Cambios introducidos

- Se documentaron los query params `page` y `limit`, que faltaban en `GET /characters`

## Ejemplo
![ejemplo](https://user-images.githubusercontent.com/58740322/168726964-02f948a5-f1d1-4288-b80a-c1158ca31f6d.png)