### PR TITLE
unit tests decorators

### DIFF
--- a/tests/unit/decorators/hide-null.decorator.spec.ts
+++ b/tests/unit/decorators/hide-null.decorator.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { instanceToPlain } from 'class-transformer';
+import HideNull from '../../../src/decorators/hide-null.decorator';
+
+describe('@HideNull tests', () => {
+  class ExampleClass {
+    @HideNull()
+    public nullableProp: string | null;
+
+    public nonNullableProp: string;
+
+    public constructor(nullableProp: string | null, nonNullableProp: string) {
+      this.nullableProp = nullableProp;
+      this.nonNullableProp = nonNullableProp;
+    }
+  }
+
+  it('should hide prop set to null', () => {
+    const instance = new ExampleClass(null, 'test');
+
+    expect(
+      instanceToPlain(instance, { exposeUnsetFields: false }),
+    ).to.deep.equal({ nonNullableProp: 'test' });
+  });
+
+  it('should not hide prop if it is not null', () => {
+    const instance = new ExampleClass('not null', 'test');
+
+    expect(
+      instanceToPlain(instance, { exposeUnsetFields: false }),
+    ).to.deep.equal({ nullableProp: 'not null', nonNullableProp: 'test' });
+  });
+});

--- a/tests/unit/decorators/is-equal-to-property.decorator.spec.ts
+++ b/tests/unit/decorators/is-equal-to-property.decorator.spec.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import { validateSync } from 'class-validator';
+import IsEqualToProperty from '../../../src/decorators/is-equal-to-property.decorator';
+
+describe('@IsEqualToProperty tests', () => {
+  class ExampleClass {
+    password: string;
+
+    @IsEqualToProperty('password')
+    passwordConfirmation: string;
+
+    constructor(password: string, passwordConfirmation: string) {
+      this.password = password;
+      this.passwordConfirmation = passwordConfirmation;
+    }
+  }
+
+  it('should validate is passwords are equal', () => {
+    const instance = new ExampleClass('12345', '12345');
+
+    expect(validateSync(instance).length).to.equal(0);
+  });
+
+  it('should not validate is passwords are different', () => {
+    const instance = new ExampleClass('12345', '123456');
+
+    expect(validateSync(instance).length).to.equal(1);
+  });
+});

--- a/tests/unit/decorators/normalize-email.decorator.spec.ts
+++ b/tests/unit/decorators/normalize-email.decorator.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { instanceToPlain } from 'class-transformer';
+import NormalizeEmail from '../../../src/decorators/normalize-email.decorator';
+
+describe('@NormalizeEmail tests', () => {
+  class ExampleClass {
+    @NormalizeEmail()
+    email?: string;
+  }
+
+  it('should normalize email', () => {
+    const instance = new ExampleClass();
+    instance.email = 'SOME.name+me@GMAIL.com';
+
+    expect(instanceToPlain(instance)).to.deep.equal({
+      email: 'somename@gmail.com',
+    });
+  });
+
+  it('should skip undefined props', () => {
+    const instance = new ExampleClass();
+    instance.email = undefined;
+
+    expect(instanceToPlain(instance)).to.deep.equal({ email: undefined });
+  });
+});

--- a/tests/unit/decorators/normalize-query-param-string.decorator.spec.ts
+++ b/tests/unit/decorators/normalize-query-param-string.decorator.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { plainToInstance } from 'class-transformer';
+import NormalizeQueryParamString from '../../../src/decorators/normalize-query-param-string.decorator';
+
+describe('@NormalizeQueryParamString tests', () => {
+  class ExampleClass {
+    @NormalizeQueryParamString()
+    foo?: string;
+
+    @NormalizeQueryParamString()
+    bar?: string;
+
+    @NormalizeQueryParamString()
+    baz?: string;
+  }
+
+  it('should convert props to strings', () => {
+    const plain = { foo: null, bar: false, baz: ['test'] };
+
+    expect({ ...plainToInstance(ExampleClass, plain) }).to.deep.equal({
+      foo: null,
+      bar: 'false',
+      baz: 'test',
+    });
+  });
+});

--- a/tests/unit/decorators/to-numeric-filter.decorator.spec.ts
+++ b/tests/unit/decorators/to-numeric-filter.decorator.spec.ts
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+import { plainToInstance } from 'class-transformer';
+import NumericFilter from '../../../src/models/types/numeric-filter.type';
+import ToNumericFilter from '../../../src/decorators/to-numeric-filter.decorator';
+
+describe('@ToNumericFilter tests', () => {
+  class ExampleClass {
+    @ToNumericFilter()
+    foo?: NumericFilter | null;
+
+    @ToNumericFilter()
+    bar?: NumericFilter | null;
+  }
+
+  it('values are unset', () => {
+    const plain = { foo: null, bar: undefined };
+
+    expect({ ...plainToInstance(ExampleClass, plain) }).to.deep.equal({
+      foo: null,
+      bar: undefined,
+    });
+  });
+
+  it('values are strings', () => {
+    const plain = { foo: '1234', bar: '' };
+
+    expect({ ...plainToInstance(ExampleClass, plain) }).to.deep.equal({
+      foo: { eq: 1234 },
+      bar: { eq: null },
+    });
+  });
+
+  it('values are arrays', () => {
+    const plain = { foo: ['1234'], bar: [''] };
+    it;
+
+    expect({ ...plainToInstance(ExampleClass, plain) }).to.deep.equal({
+      foo: { eq: 1234 },
+      bar: { eq: null },
+    });
+  });
+
+  it('values are objects', () => {
+    const plain = {
+      foo: { gte: '4', lte: '45' },
+      bar: { eq: ['123'], lte: false, gte: ['fff'] },
+    };
+
+    expect({ ...plainToInstance(ExampleClass, plain) }).to.deep.equal({
+      foo: { gte: 4, lte: 45 },
+      bar: { eq: 123, lte: null, gte: null },
+    });
+  });
+
+  it('values are of the wrong type', () => {
+    const plain = { foo: { invalidProp: '123' }, bar: true };
+
+    expect({ ...plainToInstance(ExampleClass, plain) }).to.deep.equal({
+      foo: {},
+      bar: {},
+    });
+  });
+});

--- a/tests/unit/decorators/trim.decorator.spec.ts
+++ b/tests/unit/decorators/trim.decorator.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { plainToInstance } from 'class-transformer';
+import Trim from '../../../src/decorators/trim.decorator';
+expect;
+
+describe('@Trim tests', () => {
+  class ExampleClass {
+    @Trim()
+    foo!: string | number;
+
+    @Trim()
+    bar!: string | number;
+  }
+
+  it('should trim the props', () => {
+    const plain = { foo: ' test  ', bar: 100 };
+
+    expect({ ...plainToInstance(ExampleClass, plain) }).to.deep.equal({
+      foo: 'test',
+      bar: 100,
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -98,5 +98,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": ["./src"]
+  "include": ["./src", "./tests"]
 }


### PR DESCRIPTION
# Unit tests decorators

closes #69

## Cambios introducidos

Se agregaron tests para los decoradores

## Ejemplo

Salida de los tests:
```
  @HideNull tests
    ✔ should hide prop set to null
    ✔ should not hide prop if it is not null

  @IsEqualToProperty tests
    ✔ should validate is passwords are equal
    ✔ should not validate is passwords are different

  @NormalizeEmail tests
    ✔ should normalize email
    ✔ should skip undefined props

  @NormalizeQueryParamString tests
    ✔ should convert props to strings

  @ToNumericFilter tests
    ✔ values are unset
    ✔ values are strings
    ✔ values are arrays
    ✔ values are objects
    ✔ values are of the wrong type

  @Trim tests
    ✔ should trim the props


  13 passing (58ms)

-------------------------------------------|---------|----------|---------|---------|-------------------
File                                       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------------------------------|---------|----------|---------|---------|-------------------
All files                                  |     100 |      100 |     100 |     100 |                   
 hide-null.decorator.ts                    |     100 |      100 |     100 |     100 |                   
 is-equal-to-property.decorator.ts         |     100 |      100 |     100 |     100 |                   
 normalize-email.decorator.ts              |     100 |      100 |     100 |     100 |                   
 normalize-query-param-string.decorator.ts |     100 |      100 |     100 |     100 |                   
 to-numeric-filter.decorator.ts            |     100 |      100 |     100 |     100 |                   
 trim.decorator.ts                         |     100 |      100 |     100 |     100 |                   
-------------------------------------------|---------|----------|---------|---------|-------------------
```