### PR TITLE
test: mockear importaciones de auth

### DIFF
--- a/src/middlewares/authenticate-jwt.middleware.ts
+++ b/src/middlewares/authenticate-jwt.middleware.ts
@@ -40,8 +40,8 @@ function authenticateJwt(
   req: Request,
   res: Response,
   next: NextFunction,
-): void {
-  passport.authenticate('jwt', { session: false }, async (err, user) => {
+): Promise<void> {
+  return passport.authenticate('jwt', { session: false }, async (err, user) => {
     if (err) {
       return next(err);
     }

--- a/tests/unit/middlewares/authenticate-jwt.middleware.spec.ts
+++ b/tests/unit/middlewares/authenticate-jwt.middleware.spec.ts
@@ -9,12 +9,26 @@ import {
 import sinonChai from 'sinon-chai';
 import { mockReq, mockRes } from 'sinon-express-mock';
 import passport from 'passport';
-import authenticateJwt from '../../../src/middlewares/authenticate-jwt.middleware';
+import { noCallThru } from 'proxyquire';
+import { Request, Response, NextFunction } from 'express';
 import HttpError from '../../../src/errors/http.error';
 import HttpStatus from '../../../src/models/enums/http-status.enum';
 import User from '../../../src/models/user.model';
 
 use(sinonChai);
+
+const proxyquire = noCallThru();
+
+const authenticateJwt: (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => Promise<void> = proxyquire(
+  '../../../src/middlewares/authenticate-jwt.middleware',
+  {
+    '../auth/jwt.strategy': stub().returnsThis(),
+  },
+).default;
 
 describe('authenticateJwt tests', () => {
   const req = mockReq(),


### PR DESCRIPTION
# Mockear importaciones de auth

closes #73 

## Cambios introducidos

en el test de `authenticateJwt.middleware`, se usa `proxyquire` para mockear la importacion de `../auth/jwt.strategy`, de manera que se logra desacoplar los tests

## Ejemplo

ahora la carpeta `auth` ya no sale en el coverage
```
...

  87 passing (2s)

--------------------------------------------|---------|----------|---------|---------|-------------------
File                                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------------------------------|---------|----------|---------|---------|-------------------
All files                                   |   96.69 |    92.68 |   85.52 |   96.96 |                   
 config                                     |     100 |       90 |     100 |     100 |                   
  app.config.ts                             |     100 |       90 |     100 |     100 | 6                 
 controllers                                |     100 |      100 |     100 |     100 |   

...
```