### PR TITLE
login fixes

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -36,7 +36,7 @@
  *             message: Email is already in use.
  */
 
-import { Request, Response, NextFunction } from 'express';
+import { Request, Response } from 'express';
 import { sign } from 'jsonwebtoken';
 import { Service } from 'typedi';
 import appConfig from '../config/app.config';
@@ -60,17 +60,9 @@ export default class AuthController {
   /**
    * Logs in to a created account.
    */
-  async login(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<Response | void> {
-    try {
-      const token = await sign({ user: req.user }, appConfig.JWT_SECRET_KEY);
+  login(req: Request, res: Response): Response {
+    const token = sign({ user: req.user }, appConfig.JWT_SECRET_KEY);
 
-      return res.status(HttpStatus.OK).json({ token });
-    } catch (err) {
-      return next(err);
-    }
+    return res.status(HttpStatus.OK).json({ token });
   }
 }

--- a/src/middlewares/authenticate-jwt.middleware.ts
+++ b/src/middlewares/authenticate-jwt.middleware.ts
@@ -46,18 +46,10 @@ function authenticateJwt(
       return next(err);
     }
 
-    if (!user) {
+    if (!(user && (await User.findByPk(user.id, { attributes: ['id'] })))) {
       return next(
         new HttpError(HttpStatus.UNAUTHORIZED, 'Invalid authentication token'),
       );
-    }
-
-    /**
-     * Checks if user exists in the database.
-     * In case of the token of a deleted user being used.
-     */
-    if (!(await User.findByPk(user.id, { attributes: ['id'] }))) {
-      return next(new HttpError(HttpStatus.NOT_FOUND, 'User not found.'));
     }
 
     req.user = user;

--- a/src/middlewares/authenticate-jwt.middleware.ts
+++ b/src/middlewares/authenticate-jwt.middleware.ts
@@ -12,18 +12,6 @@
  *             statusCode: 401
  *             name: Unauthorized
  *             message: Invalid authentication token.
- *
- *     UserNotFound:
- *       description: The provided token was valid but the user it represents is not in the database.
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/HttpError'
- *           example:
- *             statusCode: 404
- *             name: Not Found
- *             message: User not found.
- *
  */
 
 import { Request, Response, NextFunction } from 'express';

--- a/src/models/dto/auth/register.dto.ts
+++ b/src/models/dto/auth/register.dto.ts
@@ -18,7 +18,7 @@
  */
 
 import { Expose } from 'class-transformer';
-import { Matches, MinLength } from 'class-validator';
+import { IsString, Matches, MinLength } from 'class-validator';
 import IsEqualToProperty from '../../../decorators/is-equal-to-property.decorator';
 import LoginDto from './login.dto';
 
@@ -43,6 +43,7 @@ export default class RegisterDto extends LoginDto {
    * Password confirmation.
    */
   @Expose()
+  @IsString()
   @IsEqualToProperty('password', { message: 'passwords do not match.' })
   passwordConfirmation!: string;
 }

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -38,8 +38,6 @@
  *           $ref: '#/components/responses/ValidationError'
  *         401:
  *           $ref: '#/components/responses/InvalidLoginCredentials'
- *         404:
- *           $ref: '#/components/responses/UserNotFound'
  *
  * components:
  *   responses:

--- a/tests/unit/controllers/auth.controller.spec.ts
+++ b/tests/unit/controllers/auth.controller.spec.ts
@@ -54,23 +54,13 @@ describe('auth controller tests', () => {
       mockSign.reset();
     });
 
-    it('should return the signed token', async () => {
-      mockSign.resolves('test');
+    it('should return the signed token', () => {
+      mockSign.returns('test');
 
-      await controller.login(req, res, next);
+      controller.login(req, res);
 
       expect(res.status).to.have.been.calledOnceWithExactly(HttpStatus.OK);
       expect(res.json).to.have.been.calledOnceWithExactly({ token: 'test' });
-    });
-
-    it('should call next', async () => {
-      const err = new Error();
-
-      mockSign.rejects(err);
-
-      await controller.login(req, res, next);
-
-      expect(next).to.have.been.calledOnceWithExactly(err);
     });
   });
 });

--- a/tests/unit/middlewares/authenticate-jwt.middleware.spec.ts
+++ b/tests/unit/middlewares/authenticate-jwt.middleware.spec.ts
@@ -70,7 +70,7 @@ describe('authenticateJwt tests', () => {
       expect(req.user).to.equal(mockToken);
     });
 
-    it('should call next with 404 error', async () => {
+    it('should call next with 401 error', async () => {
       sandbox.stub(User, 'findByPk').resolves(null);
 
       await authenticateJwt(req, res, next);
@@ -78,7 +78,7 @@ describe('authenticateJwt tests', () => {
       expect(next).to.have.been.calledOnceWithExactly(
         match
           .instanceOf(HttpError)
-          .and(match.has('status', HttpStatus.NOT_FOUND)),
+          .and(match.has('status', HttpStatus.UNAUTHORIZED)),
       );
     });
   });


### PR DESCRIPTION
# Login Fixes

closes #82 

## Cambios introducidos

- remover `async/await innecesario`
- remover respuesta 404 en el middleware `authenticate-jwt`
- arreglar errores en la documentación 