### PR TITLE
test: integration /auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "start:debug": "NODE_ENV=debug ts-node-dev --transpile-only --respawn --inspect=9229 src/index.ts",
     "prepare": "husky install",
     "test": "mocha --parallel --timeout 4000 -r ts-node/register \"tests/unit/**/*.spec.ts\"",
-    "test:coverage": "nyc --reporter=text yarn test"
+    "test:coverage": "nyc --reporter=text yarn test",
+    "test:integration": "mocha --parallel -r ts-node/register \"tests/integration/*.integration.spec.ts\""
   },
   "dependencies": {
     "@sendgrid/mail": "7.7.0",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "start:dev": "NODE_ENV=development ts-node-dev --respawn ./src/index.ts",
     "start:debug": "NODE_ENV=debug ts-node-dev --transpile-only --respawn --inspect=9229 src/index.ts",
     "prepare": "husky install",
-    "test": "mocha --parallel --timeout 4000 -r ts-node/register \"tests/unit/**/*.spec.ts\"",
+    "test": "NODE_ENV=test mocha --parallel --timeout 4000 -r ts-node/register \"tests/unit/**/*.spec.ts\"",
     "test:coverage": "nyc --reporter=text yarn test",
-    "test:integration": "mocha --parallel -r ts-node/register \"tests/integration/*.integration.spec.ts\""
+    "test:integration": "NODE_ENV=test mocha --parallel -r ts-node/register \"tests/integration/*.integration.spec.ts\""
   },
   "dependencies": {
     "@sendgrid/mail": "7.7.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@typescript-eslint/eslint-plugin": "5.19.0",
     "@typescript-eslint/parser": "5.19.0",
     "chai": "4.3.6",
+    "chai-http": "4.3.0",
     "eslint": "8.13.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-import-resolver-typescript": "2.7.1",

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -6,7 +6,9 @@ import appConfig from '../config/app.config';
  */
 const logger = createLogger({
   level: appConfig.ENVIRONMENT === 'debug' ? 'debug' : 'info',
-  transports: [new transports.Console()],
+  transports: [
+    new transports.Console({ silent: appConfig.ENVIRONMENT === 'test' }),
+  ],
   format: format.combine(
     format.timestamp(),
     format.json(),

--- a/tests/integration/auth.integration.spec.ts
+++ b/tests/integration/auth.integration.spec.ts
@@ -1,0 +1,86 @@
+import sgMail from '@sendgrid/mail';
+import { expect, request, use } from 'chai';
+import chaiHttp from 'chai-http';
+import { UniqueConstraintError } from 'sequelize';
+import { createSandbox, SinonStub } from 'sinon';
+import app from '../../src/express';
+import HttpStatus from '../../src/models/enums/http-status.enum';
+import User from '../../src/models/user.model';
+
+use(chaiHttp);
+
+describe('auth integration tests', () => {
+  const sandbox = createSandbox();
+
+  let createUserStub: SinonStub;
+
+  beforeEach(() => {
+    createUserStub = sandbox.stub();
+
+    sandbox.stub(User, 'create').callsFake(createUserStub);
+    sandbox.stub(sgMail, 'send').resolves(undefined);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('register', () => {
+    describe('valid body', () => {
+      const body = {
+        email: 'abc@def.com',
+        password: 'ABCdef123_',
+        passwordConfirmation: 'ABCdef123_',
+      };
+
+      it('should register correctly', async () => {
+        const fakeUser = sandbox.createStubInstance(User);
+        fakeUser.id = 1;
+        fakeUser.email = 'abc@def.com';
+
+        createUserStub.resolves(fakeUser);
+
+        const res = await request(app).post('/auth/register').send(body);
+
+        expect(res.status).to.equal(HttpStatus.CREATED);
+        expect(res.body).to.deep.equal({ user: { id: 1, email: body.email } });
+      });
+
+      it('user already exists - should return 409 status', async () => {
+        createUserStub.rejects(new UniqueConstraintError({}));
+
+        const res = await request(app).post('/auth/register').send(body);
+
+        expect(res.status).to.equal(HttpStatus.CONFLICT);
+        expect(res.body).to.deep.equal({
+          statusCode: HttpStatus.CONFLICT,
+          name: 'Conflict',
+          message: 'Email is already in use.',
+        });
+      });
+    });
+
+    describe('invalid body', () => {
+      const body = {
+        email: 'abc@def.com',
+        password: 'ABCdef123_',
+        passwordConfirmation: 'ABCdef123',
+      };
+
+      it('should return 400 status code', async () => {
+        const res = await request(app).post('/auth/register').send(body);
+
+        expect(res.status).to.equal(HttpStatus.BAD_REQUEST);
+
+        expect(res.body).to.deep.equal({
+          statusCode: HttpStatus.BAD_REQUEST,
+          name: 'Bad Request',
+          message: {
+            description: 'Validation error.',
+            errors: ['passwords do not match.'],
+          },
+        });
+      });
+    });
+  });
+});

--- a/tests/integration/auth.integration.spec.ts
+++ b/tests/integration/auth.integration.spec.ts
@@ -73,6 +73,14 @@ describe('auth integration tests', () => {
           message: 'Email is already in use.',
         });
       });
+
+      it('should return 500 status', async () => {
+        createUserStub.rejects(new Error());
+
+        const res = await request(app).post('/auth/register').send(body);
+
+        expect(res.status).to.equal(HttpStatus.INTERNAL_SERVER_ERROR);
+      });
     });
 
     describe('invalid body', () => {

--- a/tests/integration/auth.integration.spec.ts
+++ b/tests/integration/auth.integration.spec.ts
@@ -1,31 +1,46 @@
 import sgMail from '@sendgrid/mail';
 import { expect, request, use } from 'chai';
 import chaiHttp from 'chai-http';
+import { Express } from 'express';
 import { UniqueConstraintError } from 'sequelize';
 import { createSandbox, SinonStub } from 'sinon';
-import app from '../../src/express';
+import { noCallThru } from 'proxyquire';
 import HttpStatus from '../../src/models/enums/http-status.enum';
 import User from '../../src/models/user.model';
 
 use(chaiHttp);
 
+const proxyquire = noCallThru();
+
+const authControllerMock = proxyquire('../../src/controllers/auth.controller', {
+    jsonwebtoken: { sign: () => 'mockToken' },
+  }).default,
+  authRoutesMock = proxyquire('../../src/routes/auth.routes', {
+    '../controllers/auth.controller': authControllerMock,
+  }).default;
+
+const app: Express = proxyquire('../../src/express', {
+  './routes/auth.routes': authRoutesMock,
+}).default;
+
 describe('auth integration tests', () => {
   const sandbox = createSandbox();
-
-  let createUserStub: SinonStub;
-
-  beforeEach(() => {
-    createUserStub = sandbox.stub();
-
-    sandbox.stub(User, 'create').callsFake(createUserStub);
-    sandbox.stub(sgMail, 'send').resolves(undefined);
-  });
 
   afterEach(() => {
     sandbox.restore();
   });
 
   describe('register', () => {
+    let createUserStub: SinonStub;
+
+    beforeEach(() => {
+      createUserStub = sandbox.stub();
+
+      sandbox.stub(User, 'create').callsFake(createUserStub);
+      sandbox.stub(sgMail, 'send').resolves(undefined);
+      sandbox.stub(sgMail, 'setApiKey').returns(undefined);
+    });
+
     describe('valid body', () => {
       const body = {
         email: 'abc@def.com',
@@ -78,6 +93,64 @@ describe('auth integration tests', () => {
           message: {
             description: 'Validation error.',
             errors: ['passwords do not match.'],
+          },
+        });
+      });
+    });
+  });
+
+  describe('login', () => {
+    describe('valid request body', () => {
+      const body = { email: 'abc@def.com', password: 'ABCdef123_' };
+
+      it('should log in successfully', async () => {
+        sandbox
+          .stub(User, 'checkUser')
+          .resolves(sandbox.createStubInstance(User));
+
+        const res = await request(app).post('/auth/login').send(body);
+
+        expect(res.status).to.equal(HttpStatus.OK);
+        expect(res.body).to.deep.equal({ token: 'mockToken' });
+      });
+
+      it('should return 401 response', async () => {
+        sandbox.stub(User, 'checkUser').resolves(null);
+
+        const res = await request(app).post('/auth/login').send(body);
+
+        expect(res.status).to.equal(HttpStatus.UNAUTHORIZED);
+
+        expect(res.body).to.deep.equal({
+          statusCode: HttpStatus.UNAUTHORIZED,
+          name: 'Unauthorized',
+          message: 'Invalid email or password.',
+        });
+      });
+
+      it('should return 500 response', async () => {
+        sandbox.stub(User, 'checkUser').rejects(new Error());
+
+        const res = await request(app).post('/auth/login').send(body);
+
+        expect(res.status).to.equal(HttpStatus.INTERNAL_SERVER_ERROR);
+      });
+    });
+
+    describe('invalid request body', () => {
+      const body = { email: 'abc@def.com', password: 123 };
+
+      it('should return a 400 response', async () => {
+        const res = await request(app).post('/auth/login').send(body);
+
+        expect(res.status).to.equal(HttpStatus.BAD_REQUEST);
+
+        expect(res.body).to.deep.equal({
+          statusCode: HttpStatus.BAD_REQUEST,
+          name: 'Bad Request',
+          message: {
+            description: 'Validation error.',
+            errors: ['password must be a string'],
           },
         });
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -453,7 +453,7 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/chai@*", "@types/chai@4.3.1":
+"@types/chai@*", "@types/chai@4", "@types/chai@4.3.1":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
   integrity sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==
@@ -464,6 +464,11 @@
   integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
   dependencies:
     "@types/node" "*"
+
+"@types/cookiejar@*":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
+  integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
 
 "@types/cors@2.8.12":
   version "2.8.12"
@@ -638,6 +643,14 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
+
+"@types/superagent@^3.8.3":
+  version "3.8.7"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-3.8.7.tgz#1f1ed44634d5459b3a672eb7235a8e7cfd97704c"
+  integrity sha512-9KhCkyXv268A2nZ1Wvu7rQWM+BmdYUVkycFeNnYrUL5Zwu7o8wPQ3wBfW59dDP+wuoxw0ww8YKgTNv8j/cgscA==
+  dependencies:
+    "@types/cookiejar" "*"
+    "@types/node" "*"
 
 "@types/swagger-jsdoc@6.0.1":
   version "6.0.1"
@@ -937,6 +950,11 @@ async@^3.2.3:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
@@ -1088,6 +1106,19 @@ caniuse-lite@^1.0.30001349:
   version "1.0.30001349"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001349.tgz#90740086a2eb2e825084944169d313c9793aeba4"
   integrity sha512-VFaWW3jeo6DLU5rwdiasosxhYSduJgSGil4cSyX3/85fbctlE58pXAkWyuRmVA0r2RxsOSVYUTZcySJ8WpbTxw==
+
+chai-http@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/chai-http/-/chai-http-4.3.0.tgz#3c37c675c1f4fe685185a307e345de7599337c1a"
+  integrity sha512-zFTxlN7HLMv+7+SPXZdkd5wUlK+KxH6Q7bIEMiEx0FK3zuuMqL7cwICAQ0V1+yYRozBburYuxN1qZstgHpFZQg==
+  dependencies:
+    "@types/chai" "4"
+    "@types/superagent" "^3.8.3"
+    cookiejar "^2.1.1"
+    is-ip "^2.0.0"
+    methods "^1.1.2"
+    qs "^6.5.1"
+    superagent "^3.7.0"
 
 chai@4.3.6:
   version "4.3.6"
@@ -1272,6 +1303,13 @@ colorspace@1.1.x:
     color "^3.1.3"
     text-hex "1.0.x"
 
+combined-stream@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
@@ -1291,6 +1329,11 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
+
+component-emitter@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1339,6 +1382,16 @@ cookie@0.4.2:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
+cookiejar@^2.1.0, cookiejar@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.3.tgz#fc7a6216e408e74414b90230050842dacda75acc"
+  integrity sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
 cors@2.8.5:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
@@ -1383,7 +1436,7 @@ debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, de
   dependencies:
     ms "2.1.2"
 
-debug@^3.2.7:
+debug@^3.1.0, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -1431,6 +1484,11 @@ define-properties@^1.1.3, define-properties@^1.1.4:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -1910,6 +1968,11 @@ ext@^1.1.2:
   dependencies:
     type "^2.5.0"
 
+extend@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -2050,6 +2113,20 @@ foreground-child@^2.0.0:
   dependencies:
     cross-spawn "^7.0.0"
     signal-exit "^3.0.2"
+
+form-data@^2.3.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+formidable@^1.2.0:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.6.tgz#d2a51d60162bbc9b4a055d8457a7c75315d1a168"
+  integrity sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -2395,7 +2472,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2413,6 +2490,11 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+ip-regex@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -2486,6 +2568,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-ip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-2.0.0.tgz#68eea07e8a0a0a94c2d080dd674c731ab2a461ab"
+  integrity sha512-9MTn0dteHETtyUx8pxqMwg5hMBi3pvlyglJ+b79KOCca0po23337LbVV2Hl4xmMvfw++ljnO0/+5G6G+0Szh6g==
+  dependencies:
+    ip-regex "^2.0.0"
 
 is-negative-zero@^2.0.2:
   version "2.0.2"
@@ -2579,6 +2668,11 @@ isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2997,7 +3091,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@~1.1.2:
+methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
@@ -3015,14 +3109,14 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
 
-mime@1.6.0:
+mime@1.6.0, mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -3610,6 +3704,11 @@ prettier@2.6.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
   integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
 process-on-spawn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/process-on-spawn/-/process-on-spawn-1.0.0.tgz#95b05a23073d30a17acfdc92a440efd2baefdc93"
@@ -3654,6 +3753,13 @@ qs@6.9.7:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
   integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
 
+qs@^6.5.1:
+  version "6.10.5"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.5.tgz#974715920a80ff6a262264acd2c7e6c2a53282b4"
+  integrity sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==
+  dependencies:
+    side-channel "^1.0.4"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -3680,6 +3786,19 @@ raw-body@2.4.3:
     http-errors "1.8.1"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+readable-stream@^2.3.5:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
@@ -3808,7 +3927,7 @@ safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.1:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -4117,6 +4236,13 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -4155,6 +4281,22 @@ strip-json-comments@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+superagent@^3.7.0:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  integrity sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
 
 supports-color@8.1.1:
   version "8.1.1"
@@ -4479,7 +4621,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-util-deprecate@^1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
# Integration /auth

closes #22 

## Cambios introducidos

- **agregar integration testing para los endpoints de `/auth`**
- instalar la librería `chai-http` para los tests
-  desactivar el logger en los tests

## Ejemplo

salida de los tests:
```
  auth integration tests
    register
      valid body
        ✔ should register correctly (405ms)
        ✔ user already exists - should return 409 status
        ✔ should return 500 status
      invalid body
        ✔ should return 400 status code
    login
      valid request body
        ✔ should log in successfully
        ✔ should return 401 response
        ✔ should return 500 response
      invalid request body
        ✔ should return a 400 response


  8 passing (29s)
```