### PR TITLE
test: dejar de modificar `process.env` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start:dev": "NODE_ENV=development ts-node-dev --respawn ./src/index.ts",
     "start:debug": "NODE_ENV=debug ts-node-dev --transpile-only --respawn --inspect=9229 src/index.ts",
     "prepare": "husky install",
-    "test": "NODE_ENV=test mocha --parallel --timeout 4000 -r ts-node/register \"tests/unit/**/*.spec.ts\"",
+    "test": "NODE_ENV=test mocha --parallel -r ts-node/register \"tests/unit/**/*.spec.ts\"",
     "test:coverage": "nyc --reporter=text yarn test",
     "test:integration": "NODE_ENV=test mocha --parallel -r ts-node/register \"tests/integration/*.integration.spec.ts\""
   },

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "husky": "7.0.4",
     "lint-staged": "12.4.0",
     "mocha": "10.0.0",
+    "mocked-env": "1.3.5",
     "nyc": "15.1.0",
     "prettier": "2.6.2",
     "proxyquire": "2.1.3",

--- a/tests/unit/config/app.config.spec.ts
+++ b/tests/unit/config/app.config.spec.ts
@@ -1,10 +1,19 @@
 import { expect } from 'chai';
+import mockedEnv, { RestoreFn } from 'mocked-env';
 import { noPreserveCache } from 'proxyquire';
 
 const proxyquire = noPreserveCache();
 
 describe('app config tests', () => {
+  let restore: RestoreFn;
+
+  afterEach(() => {
+    restore();
+  });
+
   it('should use default config', () => {
+    restore = mockedEnv({ clear: true });
+
     const { default: appConfig } = proxyquire(
       '../../../src/config/app.config',
       {},
@@ -20,11 +29,13 @@ describe('app config tests', () => {
   });
 
   it('should use provided env variables', () => {
-    process.env.NODE_ENV = 'debug';
-    process.env.SERVER_PORT = '5500';
-    process.env.JWT_SECRET_KEY = 'abcdef';
-    process.env.SENDGRID_API_KEY = 'SG.abcdef';
-    process.env.SENDGRID_EMAIL = 'abc@def.com';
+    restore = mockedEnv({
+      NODE_ENV: 'debug',
+      SERVER_PORT: '5500',
+      JWT_SECRET_KEY: 'abcdef',
+      SENDGRID_API_KEY: 'SG.abcdef',
+      SENDGRID_EMAIL: 'abc@def.com',
+    });
 
     const { default: appConfig } = proxyquire(
       '../../../src/config/app.config',
@@ -38,13 +49,5 @@ describe('app config tests', () => {
       SENDGRID_API_KEY: 'SG.abcdef',
       SENDGRID_EMAIL: 'abc@def.com',
     });
-  });
-
-  after(() => {
-    delete process.env.NODE_ENV;
-    delete process.env.SERVER_PORT;
-    delete process.env.JWT_SECRET_KEY;
-    delete process.env.SENDGRID_API_KEY;
-    delete process.env.SENDGRID_EMAIL;
   });
 });

--- a/tests/unit/logger/index.spec.ts
+++ b/tests/unit/logger/index.spec.ts
@@ -15,7 +15,7 @@ describe('logger tests', () => {
     expect(logger.level).to.equal('info');
   });
 
-  it('should be called with non debug info', () => {
+  it('should be called with debug info', () => {
     const logger: Logger = proxyquire('../../../src/logger', {
       '../config/app.config': {
         default: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,6 +1155,11 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
+check-more-types@2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
+  integrity sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==
+
 chokidar@3.5.3, chokidar@^3.5.1:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
@@ -1433,6 +1438,13 @@ debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, de
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
@@ -2848,6 +2860,11 @@ kuler@^2.0.0:
   resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
   integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
 
+lazy-ass@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
+  integrity sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -3192,6 +3209,16 @@ mocha@10.0.0:
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
+
+mocked-env@1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/mocked-env/-/mocked-env-1.3.5.tgz#244eabdc1ed92a8f6f55a2faedc408159eb193b3"
+  integrity sha512-GyYY6ynVOdEoRlaGpaq8UYwdWkvrsU2xRme9B+WPSuJcNjh17+3QIxSYU6zwee0SbehhV6f06VZ4ahjG+9zdrA==
+  dependencies:
+    check-more-types "2.24.0"
+    debug "4.3.2"
+    lazy-ass "1.6.0"
+    ramda "0.27.1"
 
 module-not-found-error@^1.0.1:
   version "1.0.1"
@@ -3764,6 +3791,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+ramda@0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
 
 randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
# Dejar de modificar `process.env`

closes #85 

## Cambios introducidos

- usar [mocked-env](https://github.com/bahmutov/mocked-env) para setear las variables de entorno y después restaurarlas
- optimizar los test de la funcion `bootstrap`
- bajar el timeout  de los tests a 2000ms (ya que se optimizaron)