### PR TITLE
Usar class-transformer-validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@sendgrid/mail": "7.7.0",
     "bcrypt": "5.0.1",
     "class-transformer": "0.5.1",
+    "class-transformer-validator": "0.9.1",
     "class-validator": "0.13.2",
     "cors": "2.8.5",
     "dotenv": "16.0.0",

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../tsconfig.json",
+    "include": ["."]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1180,6 +1180,11 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
+class-transformer-validator@0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/class-transformer-validator/-/class-transformer-validator-0.9.1.tgz#81af4bab5e13ce619a25a74cc70f723a8c4e2779"
+  integrity sha512-83/KFCyd6UiiwH6PlQS5y17O5TTx58CawvNI+XdrMs0Ig9QI5kiuzRqGcC/WrEpd1F7i4KIxCwdn6m4B6fl0jw==
+
 class-transformer@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.5.1.tgz#24147d5dffd2a6cea930a3250a677addf96ab336"


### PR DESCRIPTION
# Usar class-transformer validator

para simplificar un poco la lógica del middleware de validación

## Cammbios introducidos

- **usar el plugin de class-transformer-validator en vez de las dos librerías por separado**
- cambiar los tests unitarios del middleware para que usen la nueva libreria
- agregar un tsconfig.json a la carpeta de tests para que no aparezcan errores en el editor de codigo