### PR TITLE
Mejoras en los tests unitarios

### DIFF
--- a/src/routes/common.routes.ts
+++ b/src/routes/common.routes.ts
@@ -51,7 +51,7 @@ export default abstract class CommonRoutes {
   private basePath: string;
   protected router: Router;
 
-  public constructor(basePath = '') {
+  public constructor(basePath: string) {
     this.basePath = basePath;
     this.router = Router();
   }

--- a/tests/unit/controllers/auth.controller.spec.ts
+++ b/tests/unit/controllers/auth.controller.spec.ts
@@ -17,6 +17,20 @@ describe('auth controller tests', () => {
     res = mockRes(),
     next = stub();
 
+  const mockSign = stub();
+  const AuthControllerStubbed = proxyquire(
+    '../../../src/controllers/auth.controller',
+    {
+      jsonwebtoken: { sign: mockSign },
+    },
+  ).default;
+
+  let controller: AuthController;
+
+  beforeEach(() => {
+    controller = new AuthControllerStubbed();
+  });
+
   afterEach(() => {
     res.status.resetHistory();
     res.json.resetHistory();
@@ -24,8 +38,6 @@ describe('auth controller tests', () => {
   });
 
   describe('register', () => {
-    const controller = new AuthController();
-
     it('should emit an event an return correct response', async () => {
       await controller.register(req, res);
 
@@ -39,17 +51,6 @@ describe('auth controller tests', () => {
   });
 
   describe('login', () => {
-    const mockSign = stub();
-
-    const AuthControllerStubbed = proxyquire(
-      '../../../src/controllers/auth.controller',
-      {
-        jsonwebtoken: { sign: mockSign },
-      },
-    ).default;
-
-    const controller: AuthController = new AuthControllerStubbed();
-
     afterEach(() => {
       mockSign.reset();
     });

--- a/tests/unit/express.spec.ts
+++ b/tests/unit/express.spec.ts
@@ -1,0 +1,34 @@
+import { MailService } from '@sendgrid/mail';
+import { expect, use } from 'chai';
+import { Express } from 'express';
+import { noCallThru } from 'proxyquire';
+import { createStubInstance } from 'sinon';
+import sinonChai from 'sinon-chai';
+
+use(sinonChai);
+
+const proxyquire = noCallThru();
+
+describe('express function tests', () => {
+  const mockMailService = createStubInstance(MailService);
+
+  const app: Express = proxyquire('../../src/express', {
+    typedi: {
+      Container: {
+        get: () => mockMailService,
+        import: function () {
+          return this;
+        },
+        getMany: () => [],
+      },
+    },
+  }).default;
+
+  it('should listen to event', () => {
+    app.emit('event:userCreated', 'abc@def.com');
+
+    expect(mockMailService.send).to.have.been.calledOnceWithExactly(
+      'abc@def.com',
+    );
+  });
+});

--- a/tests/unit/middlewares/authenticate-jwt.middleware.spec.ts
+++ b/tests/unit/middlewares/authenticate-jwt.middleware.spec.ts
@@ -9,26 +9,12 @@ import {
 import sinonChai from 'sinon-chai';
 import { mockReq, mockRes } from 'sinon-express-mock';
 import passport from 'passport';
-import { noCallThru } from 'proxyquire';
-import { Request, Response, NextFunction } from 'express';
+import authenticateJwt from '../../../src/middlewares/authenticate-jwt.middleware';
 import HttpError from '../../../src/errors/http.error';
 import HttpStatus from '../../../src/models/enums/http-status.enum';
 import User from '../../../src/models/user.model';
 
 use(sinonChai);
-
-const proxyquire = noCallThru();
-
-const authenticateJwt: (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => Promise<void> = proxyquire(
-  '../../../src/middlewares/authenticate-jwt.middleware',
-  {
-    '../auth/jwt.strategy': stub().returnsThis(),
-  },
-).default;
 
 describe('authenticateJwt tests', () => {
   const req = mockReq(),

--- a/tests/unit/middlewares/error-logger.middleware.spec.ts
+++ b/tests/unit/middlewares/error-logger.middleware.spec.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import { spy, stub } from 'sinon';
+import { mockReq, mockRes } from 'sinon-express-mock';
+import HttpError from '../../../src/errors/http.error';
+import logger from '../../../src/logger';
+import errorLogger from '../../../src/middlewares/error-logger.middleware';
+
+describe('error logger tests', () => {
+  const loggerSpy = spy(logger, 'log');
+
+  const req = mockReq(),
+    res = mockRes(),
+    next = stub();
+
+  afterEach(() => {
+    loggerSpy.resetHistory();
+  });
+
+  after(() => {
+    loggerSpy.restore();
+  });
+
+  it('should not skip logging', () => {
+    errorLogger(new Error(), req, res, next);
+
+    expect(loggerSpy).to.have.been.calledOnce;
+  });
+
+  it('should skip logging', () => {
+    errorLogger(new HttpError(), req, res, next);
+
+    expect(loggerSpy).to.not.have.been.called;
+  });
+});

--- a/tests/unit/models/dto/characters/filter-character.dto.spec.ts
+++ b/tests/unit/models/dto/characters/filter-character.dto.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import { plainToInstance } from 'class-transformer';
+import FilterCharacterDto from '../../../../../src/models/dto/characters/filter-character.dto';
+
+describe('FilterCharacterDto tests', () => {
+  it('should skip transformation on undefined', () => {
+    const plain = {};
+
+    const instance = plainToInstance(FilterCharacterDto, plain, {
+      excludeExtraneousValues: true,
+      exposeUnsetFields: false,
+    });
+
+    expect(instance).to.not.have.property('movies');
+  });
+
+  it('should convert numeric strings to numbers', () => {
+    const plain = { movies: ['123'] };
+
+    const instance = plainToInstance(FilterCharacterDto, plain);
+
+    expect(instance).to.have.deep.property('movies', [123]);
+  });
+
+  it('should convert non numeric strings to null', () => {
+    const plain = { movies: [''] };
+
+    const instance = plainToInstance(FilterCharacterDto, plain);
+
+    expect(instance).to.have.deep.property('movies', [null]);
+  });
+});

--- a/tests/unit/models/dto/movies/filter-movie.dto.spec.ts
+++ b/tests/unit/models/dto/movies/filter-movie.dto.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from 'chai';
+import { plainToInstance } from 'class-transformer';
+import FilterMovieDto from '../../../../../src/models/dto/movies/filter-movie.dto';
+
+describe('FilterMovieDto tests', () => {
+  describe('genre', () => {
+    it('should skip transformation on undefined', () => {
+      const plain = {};
+
+      const instance = plainToInstance(FilterMovieDto, plain, {
+        excludeExtraneousValues: true,
+        exposeUnsetFields: false,
+      });
+
+      expect(instance).to.not.have.property('genre');
+    });
+
+    it('should convert numeric strings to numbers', () => {
+      const plain = { genre: '123' };
+
+      const instance = plainToInstance(FilterMovieDto, plain);
+
+      expect(instance).to.have.property('genre', 123);
+    });
+
+    it('should convert non numeric strings to null', () => {
+      const plain = { genre: '' };
+
+      const instance = plainToInstance(FilterMovieDto, plain);
+
+      expect(instance).to.have.deep.property('genre', null);
+    });
+
+    it('should also work with arrays', () => {
+      const plain = { genre: ['123', '456'] };
+
+      const instance = plainToInstance(FilterMovieDto, plain);
+
+      expect(instance).to.have.property('genre', 123);
+    });
+  });
+
+  describe('order', () => {
+    it('should be ASC', () => {
+      const plain = {};
+
+      const instance = plainToInstance(FilterMovieDto, plain);
+
+      expect(instance).to.have.property('order', 'ASC');
+    });
+
+    it('should be DESC', () => {
+      const plain = { order: 'desc' };
+
+      const instance = plainToInstance(FilterMovieDto, plain);
+
+      expect(instance).to.have.property('order', 'DESC');
+    });
+  });
+});

--- a/tests/unit/models/user.model.spec.ts
+++ b/tests/unit/models/user.model.spec.ts
@@ -1,7 +1,9 @@
 import { expect } from 'chai';
-import proxyquire from 'proxyquire';
+import { noCallThru } from 'proxyquire';
 import { createStubInstance, stub } from 'sinon';
 import User from '../../../src/models/user.model';
+
+const proxyquire = noCallThru();
 
 describe('user model tests', () => {
   const compareStub = stub();


### PR DESCRIPTION
# Mejoras en los tests unitarios

## Cambios introducidos

- Se limitó el uso de `proxyquire` donde no era necesario, haciendo que los tests corran más rápido
- Se agregaron tests para funciones que no estaban testeadas

## Ejemplo

code coverage

```
--------------------------------------------|---------|----------|---------|---------|-------------------
File                                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------------------------------|---------|----------|---------|---------|-------------------
All files                                   |     100 |      100 |     100 |     100 |                   
 src                                        |     100 |      100 |     100 |     100 |                   
  bootstrap.ts                              |     100 |      100 |     100 |     100 |                   
  express.ts                                |     100 |      100 |     100 |     100 |                   
 src/config                                 |     100 |      100 |     100 |     100 |                   
  app.config.ts                             |     100 |      100 |     100 |     100 |                   
  db.config.ts                              |     100 |      100 |     100 |     100 |                   
  swagger.config.ts                         |     100 |      100 |     100 |     100 |                   
 src/controllers                            |     100 |      100 |     100 |     100 |                   
  auth.controller.ts                        |     100 |      100 |     100 |     100 |                   
  characters.controller.ts                  |     100 |      100 |     100 |     100 |                   
  movies.controller.ts                      |     100 |      100 |     100 |     100 |                   
 src/controllers/services                   |     100 |      100 |     100 |     100 |                   
  characters.service.ts                     |     100 |      100 |     100 |     100 |                   
  mail.service.ts                           |     100 |      100 |     100 |     100 |                   
  movies.service.ts                         |     100 |      100 |     100 |     100 |                   
 src/database                               |     100 |      100 |     100 |     100 |                   
  connection.ts                             |     100 |      100 |     100 |     100 |                   
  seeder.ts                                 |     100 |      100 |     100 |     100 |                   
  umzug.ts                                  |     100 |      100 |     100 |     100 |                   
 src/decorators                             |     100 |      100 |     100 |     100 |                   
  hide-null.decorator.ts                    |     100 |      100 |     100 |     100 |                   
  is-equal-to-property.decorator.ts         |     100 |      100 |     100 |     100 |                   
  normalize-email.decorator.ts              |     100 |      100 |     100 |     100 |                   
  normalize-query-param-string.decorator.ts |     100 |      100 |     100 |     100 |                   
  to-numeric-filter.decorator.ts            |     100 |      100 |     100 |     100 |                   
  trim.decorator.ts                         |     100 |      100 |     100 |     100 |                   
 src/errors                                 |     100 |      100 |     100 |     100 |                   
  http.error.ts                             |     100 |      100 |     100 |     100 |                   
 src/logger                                 |     100 |      100 |     100 |     100 |                   
  index.ts                                  |     100 |      100 |     100 |     100 |                   
 src/middlewares                            |     100 |      100 |     100 |     100 |                   
  authenticate-jwt.middleware.ts            |     100 |      100 |     100 |     100 |                   
  error-handler.middleware.ts               |     100 |      100 |     100 |     100 |                   
  error-logger.middleware.ts                |     100 |      100 |     100 |     100 |                   
  fallback-error-transformer.middleware.ts  |     100 |      100 |     100 |     100 |                   
  request-logger.middleware.ts              |     100 |      100 |     100 |     100 |                   
  syntax-error-handler.middleware.ts        |     100 |      100 |     100 |     100 |                   
  validate-request.middleware.ts            |     100 |      100 |     100 |     100 |                   
 src/models                                 |     100 |      100 |     100 |     100 |                   
  character.model.ts                        |     100 |      100 |     100 |     100 |                   
  genre.model.ts                            |     100 |      100 |     100 |     100 |                   
  movie-character.model.ts                  |     100 |      100 |     100 |     100 |                   
  movie.model.ts                            |     100 |      100 |     100 |     100 |                   
  user.model.ts                             |     100 |      100 |     100 |     100 |                   
 src/models/dto                             |     100 |      100 |     100 |     100 |                   
  id-param.dto.ts                           |     100 |      100 |     100 |     100 |                   
  paginate.dto.ts                           |     100 |      100 |     100 |     100 |                   
 src/models/dto/auth                        |     100 |      100 |     100 |     100 |                   
  login.dto.ts                              |     100 |      100 |     100 |     100 |                   
  register.dto.ts                           |     100 |      100 |     100 |     100 |                   
 src/models/dto/characters                  |     100 |      100 |     100 |     100 |                   
  create-character.dto.ts                   |     100 |      100 |     100 |     100 |                   
  filter-character.dto.ts                   |     100 |      100 |     100 |     100 |                   
  update-character.dto.ts                   |     100 |      100 |     100 |     100 |                   
 src/models/dto/movies                      |     100 |      100 |     100 |     100 |                   
  add-movie-character.dto.ts                |     100 |      100 |     100 |     100 |                   
  create-movie.dto.ts                       |     100 |      100 |     100 |     100 |                   
  filter-movie.dto.ts                       |     100 |      100 |     100 |     100 |                   
  remove-movie-character.dto.ts             |     100 |      100 |     100 |     100 |                   
  update-movie.dto.ts                       |     100 |      100 |     100 |     100 |                   
 src/models/enums                           |     100 |      100 |     100 |     100 |                   
  http-status.enum.ts                       |     100 |      100 |     100 |     100 |                   
 src/routes                                 |     100 |      100 |     100 |     100 |                   
  auth.routes.ts                            |     100 |      100 |     100 |     100 |                   
  characters.routes.ts                      |     100 |      100 |     100 |     100 |                   
  common.routes.ts                          |     100 |      100 |     100 |     100 |                   
  movies.routes.ts                          |     100 |      100 |     100 |     100 |                   
--------------------------------------------|---------|----------|---------|---------|-------------------
```