### PR TITLE
e2e test auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,8 @@ SENDGRID_API_KEY=
 # verified email address on your sendgrid acount. welcome emails will be sent from this address.
 SENDGRID_EMAIL=
 
+## For tesing purposes - you don't need to set these if you are not going to run e2e tests.
+
 # your testmail.app api key
 TESTMAIL_API_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,9 @@ SENDGRID_API_KEY=
 
 # verified email address on your sendgrid acount. welcome emails will be sent from this address.
 SENDGRID_EMAIL=
+
+# your testmail.app api key
+TESTMAIL_API_KEY=
+
+# your testmail.app unique namespace
+TESTMAIL_NAMESPACE=

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Also you can use `docker-compose exec app yarn migrator -h` to get more useful c
 
 Seeders are run automatically when you start the app in dev or debug mode.
 
+## E2E Testing
+
+This application uses the [sendmail.app](https://sendmail.app) API to check if the welcome
+email was sent successfully, so to run the e2e tests, you'll need an account in that service,
+and provide an API key and a namespace in the .env file
+
 ## Info
 
 ### Author

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prepare": "husky install",
     "test": "NODE_ENV=test mocha --parallel -r ts-node/register \"tests/unit/**/*.spec.ts\"",
     "test:coverage": "nyc --reporter=text yarn test",
-    "test:integration": "NODE_ENV=test mocha --parallel -r reflect-metadata -r dotenv/config -r ts-node/register \"tests/integration/*.integration.spec.ts\""
+    "test:integration": "NODE_ENV=test mocha --parallel -r reflect-metadata -r dotenv/config -r ts-node/register \"tests/integration/*.integration.spec.ts\"",
+    "test:e2e": "NODE_ENV=test mocha --timeout 15000 --slow 1000 -r reflect-metadata -r dotenv/config -r ts-node/register \"tests/e2e/*.e2e.spec.ts\""
   },
   "dependencies": {
     "@sendgrid/mail": "7.7.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "husky install",
     "test": "NODE_ENV=test mocha --parallel -r ts-node/register \"tests/unit/**/*.spec.ts\"",
     "test:coverage": "nyc --reporter=text yarn test",
-    "test:integration": "NODE_ENV=test mocha --parallel -r ts-node/register \"tests/integration/*.integration.spec.ts\""
+    "test:integration": "NODE_ENV=test mocha --parallel -r reflect-metadata -r dotenv/config -r ts-node/register \"tests/integration/*.integration.spec.ts\""
   },
   "dependencies": {
     "@sendgrid/mail": "7.7.0",

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,9 +1,4 @@
-import 'reflect-metadata';
-import { config } from 'dotenv';
 import { Container } from 'typedi';
-
-config();
-
 import DbConnection from './database/connection';
 import app from './express';
 import appConfig from './config/app.config';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import 'reflect-metadata';
+import 'dotenv/config';
 import bootstrap from './bootstrap';
 
 bootstrap();

--- a/tests/e2e/auth.e2e.spec.ts
+++ b/tests/e2e/auth.e2e.spec.ts
@@ -1,0 +1,53 @@
+import { expect, request, use } from 'chai';
+import chaiHttp from 'chai-http';
+import { Sequelize } from 'sequelize-typescript';
+import { Container } from 'typedi';
+import isJwt from 'validator/lib/isJWT';
+import DbConnection from '../../src/database/connection';
+import Seeder from '../../src/database/seeder';
+import app from '../../src/express';
+import HttpStatus from '../../src/models/enums/http-status.enum';
+
+use(chaiHttp);
+
+describe('auth e2e tests', () => {
+  let db: Sequelize, seeder: Seeder;
+
+  before(async () => {
+    db = Container.get(DbConnection).getConnection();
+    await db.authenticate();
+    await db.sync({ force: true });
+
+    seeder = Container.get(Seeder);
+  });
+
+  beforeEach(async () => {
+    await seeder.initialize();
+  });
+
+  afterEach(async () => {
+    await seeder.revert();
+  });
+
+  describe('login', () => {
+    it('should return 200 status code', async () => {
+      const res = await request(app).post('/auth/login').send({
+        email: 'john.doe@domain.com',
+        password: '1234567890',
+      });
+
+      expect(res.status).to.equal(HttpStatus.OK);
+      expect(res.body).to.have.property('token');
+      expect(isJwt(res.body.token)).to.be.true;
+    });
+
+    it('should return 401 status code', async () => {
+      const res = await request(app).post('/auth/login').send({
+        email: 'john.doe@domain.com',
+        password: '123456789',
+      });
+
+      expect(res.status).to.equal(HttpStatus.UNAUTHORIZED);
+    });
+  });
+});

--- a/tests/e2e/config.ts
+++ b/tests/e2e/config.ts
@@ -1,0 +1,6 @@
+const e2eConfig = {
+  TESTMAIL_API_KEY: process.env.TESTMAIL_API_KEY,
+  TESTMAIL_NAMESPACE: process.env.TESTMAIL_NAMESPACE,
+};
+
+export default e2eConfig;


### PR DESCRIPTION
# e2e test auth

closes #25

## Cambios introducidos

- **agregar tests end to end para `/auth`**
- fix: importar `reflect-metadata` y `dotenv` en la función bootstrap
- fix: requerir `reflect-metadata` y `dotenv` en el script de `test:integration`
- actualizar readme y .env.example 