### PR TITLE
fix: usar `replacements` en query

### DIFF
--- a/src/controllers/services/characters.service.ts
+++ b/src/controllers/services/characters.service.ts
@@ -43,7 +43,7 @@ export default class CharactersService {
     if (dto.movies && dto.movies.length > 0) {
       const subQuery = `(
         SELECT "characterId" FROM "movies-characters"
-        WHERE "movieId" IN ( ${dto.movies.join(',')} )
+        WHERE "movieId" IN (:movies)
       )`;
 
       conditions.push({ id: { [Op.in]: literal(subQuery) } });
@@ -57,6 +57,7 @@ export default class CharactersService {
 
     const { count, rows } = await Character.findAndCountAll({
       attributes: ['id', 'name', 'imageUrl'],
+      replacements: { movies: dto.movies },
       where: { [Op.and]: conditions },
       limit,
       offset: skip,

--- a/tests/unit/controllers/services/characters.service.spec.ts
+++ b/tests/unit/controllers/services/characters.service.spec.ts
@@ -1,5 +1,5 @@
 import { expect, use } from 'chai';
-import { col, fn, literal, Op, where } from 'sequelize';
+import { Op } from 'sequelize';
 import { createSandbox, match, SinonSandbox, SinonStub } from 'sinon';
 import sinonChai from 'sinon-chai';
 import CharactersService from '../../../../src/controllers/services/characters.service';
@@ -51,28 +51,8 @@ describe('characters service tests', () => {
       expect(mockFindAndCountAll).to.have.been.calledWithMatch({
         limit: 1,
         offset: 0,
-        where: { [Op.and]: match.array },
+        where: { [Op.and]: match.array.and(match.has('length', 4)) },
       });
-
-      const conditions = (
-        mockFindAndCountAll.getCall(0).args[0].where as { [Op.and]: object }
-      )[Op.and];
-
-      expect(conditions).to.have.deep.members([
-        where(fn('to_tsvector', col('name')), {
-          [Op.match]: fn('plainto_tsquery', dto.name),
-        }),
-        { age: { [Op.and]: [{ [Op.gt]: 3 }, { [Op.not]: null }] } },
-        { weight: { [Op.and]: [{ [Op.lt]: 200 }, { [Op.not]: null }] } },
-        {
-          id: {
-            [Op.in]: literal(`(
-          SELECT "characterId" FROM "movies-characters"
-          WHERE "movieId" IN ( 1 )
-        )`),
-          },
-        },
-      ]);
     });
 
     it('empty parameters', async () => {

--- a/tests/unit/controllers/services/movies.service.spec.ts
+++ b/tests/unit/controllers/services/movies.service.spec.ts
@@ -1,5 +1,5 @@
 import { expect, use } from 'chai';
-import { col, fn, Op, where } from 'sequelize';
+import { Op } from 'sequelize';
 import { createSandbox, match, SinonSandbox, SinonStub } from 'sinon';
 import sinonChai from 'sinon-chai';
 import Movie from '../../../../src/models/movie.model';
@@ -53,19 +53,8 @@ describe('movies service tests', () => {
         limit: 5,
         offset: 10,
         order: [['createdAt', 'DESC']],
-        where: { [Op.and]: match.array },
+        where: { [Op.and]: match.array.and(match.has('length', 2)) },
       });
-
-      const conditions = (
-        mockFindAndCountAll.getCall(0).args[0].where as { [Op.and]: object }
-      )[Op.and];
-
-      expect(conditions).to.have.deep.members([
-        where(fn('to_tsvector', col('title')), {
-          [Op.match]: fn('plainto_tsquery', 'star wars'),
-        }),
-        { genreId: 1 },
-      ]);
     });
 
     it('empty parameters', async () => {


### PR DESCRIPTION
# Fix: usar replacaments en query

closes #95 

## Cambios introducidos

- **Usar `replacements` en vez de literal strings para pasarle argumentos a las raw queries**
- Removidos tests que daban falsos positivos

## Ejemplo

endpoint funcionando correctamente incluso con parametros que no son numericos
```sh
$ curlie -j get "http://localhost:5500/characters?movies=1&movies=asc" --pretty

{
    "data": [
        {
            "id": 1,
            "name": "Snow White",
            "imageUrl": "https://static.wikia.nocookie.net/disney/images/3/33/Profile_-_Snow_White.jpeg/revision/latest/scale-to-width-down/782?cb=20200916135241"
        },
        {
            "id": 2,
            "name": "Magic Mirror",
            "imageUrl": "https://static.wikia.nocookie.net/disney/images/f/f9/Snowwhite-disneyscreencaps.com-100.jpg/revision/latest/scale-to-width-down/223?cb=20201125093643"
        }
    ],
    "totalPages": 1,
    "total": 2
}
HTTP/1.1 200 OK
```