### PR TITLE
test(e2e): /movies

### DIFF
--- a/tests/e2e/movies.e2e.spec.ts
+++ b/tests/e2e/movies.e2e.spec.ts
@@ -1,0 +1,76 @@
+import { expect, request, use } from 'chai';
+import chaiHttp from 'chai-http';
+import { sign } from 'jsonwebtoken';
+import { Sequelize } from 'sequelize-typescript';
+import { Container } from 'typedi';
+import appConfig from '../../src/config/app.config';
+import DbConnection from '../../src/database/connection';
+import Seeder from '../../src/database/seeder';
+import app from '../../src/express';
+import HttpStatus from '../../src/models/enums/http-status.enum';
+import Movie from '../../src/models/movie.model';
+
+use(chaiHttp);
+
+describe('movies e2e tests', () => {
+  let db: Sequelize, seeder: Seeder, bearerToken: string;
+
+  before(async () => {
+    db = Container.get(DbConnection).getConnection();
+    seeder = Container.get(Seeder);
+
+    // the token will be used for future requests
+    bearerToken =
+      'Bearer ' +
+      sign(
+        { user: { id: 1, email: 'john.doe@domain.com' } },
+        appConfig.JWT_SECRET_KEY,
+      );
+
+    // clear db to seed later
+    await db.getQueryInterface().dropAllTables();
+  });
+
+  beforeEach(async () => {
+    await db.sync();
+    await seeder.initialize();
+  });
+
+  afterEach(async () => {
+    await db.getQueryInterface().dropAllTables();
+  });
+
+  describe('/movies', () => {
+    describe('post', () => {
+      it('shold return a 201 status code', async () => {
+        const countBeforeCreate = await Movie.count();
+
+        const res = await request(app)
+          .post('/movies')
+          .set('Authorization', bearerToken)
+          .send({ title: 'Chicken Little', genreId: 3 });
+
+        expect(res.status).to.equal(HttpStatus.CREATED);
+
+        expect(res.body).to.have.property('id', countBeforeCreate + 1);
+      });
+
+      it('rshould return a 401 status code', async () => {
+        const res = await request(app)
+          .post('/movies')
+          .send({ title: 'Chicken Little', genreId: 3 });
+
+        expect(res.status).to.equal(HttpStatus.UNAUTHORIZED);
+      });
+
+      it('shold return a 422 status code', async () => {
+        const res = await request(app)
+          .post('/movies')
+          .set('Authorization', bearerToken)
+          .send({ title: 'Chicken Little', genreId: 99 });
+
+        expect(res.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY);
+      });
+    });
+  });
+});

--- a/tests/e2e/movies.e2e.spec.ts
+++ b/tests/e2e/movies.e2e.spec.ts
@@ -258,5 +258,31 @@ describe('movies e2e tests', () => {
         expect(res.status).to.equal(HttpStatus.NOT_FOUND);
       });
     });
+
+    describe('delete', () => {
+      it('should return a 200 status code', async () => {
+        const res = await request(app)
+          .delete('/movies/1')
+          .set('Authorization', bearerToken);
+
+        expect(res.status).to.equal(HttpStatus.OK);
+
+        expect(await Movie.findByPk(1)).to.be.null;
+      });
+
+      it('should return 401 status code', async () => {
+        const res = await request(app).delete('/movies/1');
+
+        expect(res.status).to.equal(HttpStatus.UNAUTHORIZED);
+      });
+
+      it('should return a 404 status code', async () => {
+        const res = await request(app)
+          .delete('/movies/999')
+          .set('Authorization', bearerToken);
+
+        expect(res.status).to.equal(HttpStatus.NOT_FOUND);
+      });
+    });
   });
 });

--- a/tests/e2e/movies.e2e.spec.ts
+++ b/tests/e2e/movies.e2e.spec.ts
@@ -170,4 +170,49 @@ describe('movies e2e tests', () => {
       });
     });
   });
+
+  describe('/movies/:id', () => {
+    describe('get', () => {
+      it('should return 200 status code with a movie', async () => {
+        const res = await request(app).get('/movies/1');
+
+        expect(res.status).to.equal(HttpStatus.OK);
+
+        expect(res.body).to.deep.equal({
+          id: 1,
+          title: 'Snow White and the Seven Dwarfs',
+          genre: {
+            id: 7,
+            name: 'Fantasy',
+            imageUrl:
+              'https://st.depositphotos.com/1956729/1826/i/600/depositphotos_18265217-stock-photo-alien-world-in-winter.jpg',
+          },
+          imageUrl:
+            'https://upload.wikimedia.org/wikipedia/commons/b/b0/Snow_white_1937_trailer_screenshot.jpg',
+          rating: 4.3,
+          createdAt: new Date(1937, 12, 21).toISOString(),
+          characters: [
+            {
+              id: 1,
+              name: 'Snow White',
+              imageUrl:
+                'https://static.wikia.nocookie.net/disney/images/3/33/Profile_-_Snow_White.jpeg/revision/latest/scale-to-width-down/782?cb=20200916135241',
+            },
+            {
+              id: 2,
+              name: 'Magic Mirror',
+              imageUrl:
+                'https://static.wikia.nocookie.net/disney/images/f/f9/Snowwhite-disneyscreencaps.com-100.jpg/revision/latest/scale-to-width-down/223?cb=20201125093643',
+            },
+          ],
+        });
+      });
+
+      it('should return a 404 status code', async () => {
+        const res = await request(app).get('/movies/99');
+
+        expect(res.status).to.equal(HttpStatus.NOT_FOUND);
+      });
+    });
+  });
 });

--- a/tests/e2e/movies.e2e.spec.ts
+++ b/tests/e2e/movies.e2e.spec.ts
@@ -214,5 +214,49 @@ describe('movies e2e tests', () => {
         expect(res.status).to.equal(HttpStatus.NOT_FOUND);
       });
     });
+
+    describe('patch', () => {
+      it('should return 200 status code', async () => {
+        const res = await request(app)
+          .patch('/movies/1')
+          .set('Authorization', bearerToken)
+          .send({ title: 'test' });
+
+        expect(res.status).to.equal(HttpStatus.OK);
+
+        expect(
+          await Movie.findOne({
+            attributes: ['id'],
+            where: { id: 1, title: 'test' },
+          }),
+        ).to.not.be.null;
+      });
+
+      it('should return 401 status code', async () => {
+        const res = await request(app)
+          .patch('/movies/1')
+          .send({ title: 'test' });
+
+        expect(res.status).to.equal(HttpStatus.UNAUTHORIZED);
+      });
+
+      it('should return 422 status code', async () => {
+        const res = await request(app)
+          .patch('/movies/1')
+          .set('Authorization', bearerToken)
+          .send({ genreId: 99 });
+
+        expect(res.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY);
+      });
+
+      it('should return a 404 status code', async () => {
+        const res = await request(app)
+          .patch('/movies/99')
+          .set('Authorization', bearerToken)
+          .send({ title: 'test' });
+
+        expect(res.status).to.equal(HttpStatus.NOT_FOUND);
+      });
+    });
   });
 });

--- a/tests/e2e/movies.e2e.spec.ts
+++ b/tests/e2e/movies.e2e.spec.ts
@@ -285,4 +285,50 @@ describe('movies e2e tests', () => {
       });
     });
   });
+
+  describe('POST /movies/:id/characters', () => {
+    it('should return a 201 status code', async () => {
+      const res = await request(app)
+        .post('/movies/1/characters')
+        .set('Authorization', bearerToken)
+        .send({ characterId: 3 });
+
+      expect(res.status).to.equal(HttpStatus.CREATED);
+    });
+
+    it('should return 401 status code', async () => {
+      const res = await request(app)
+        .post('/movies/1/characters')
+        .send({ characterId: 3 });
+
+      expect(res.status).to.equal(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('should return a 409 status code', async () => {
+      const res = await request(app)
+        .post('/movies/1/characters')
+        .set('Authorization', bearerToken)
+        .send({ characterId: 1 });
+
+      expect(res.status).to.equal(HttpStatus.CONFLICT);
+    });
+
+    it('should return a 422 status code', async () => {
+      const res = await request(app)
+        .post('/movies/1/characters')
+        .set('Authorization', bearerToken)
+        .send({ characterId: 99 });
+
+      expect(res.status).to.equal(HttpStatus.UNPROCESSABLE_ENTITY);
+    });
+
+    it('should return a 404 status code', async () => {
+      const res = await request(app)
+        .post('/movies/99/characters')
+        .set('Authorization', bearerToken)
+        .send({ characterId: 1 });
+
+      expect(res.status).to.equal(HttpStatus.NOT_FOUND);
+    });
+  });
 });


### PR DESCRIPTION
# Test e2e movies

closes #26

## Cambios introducidos

Agregados tests e2e para movies

## Ejemplo

salida de los tests
```
  movies e2e tests
    /movies
      get
        ✔ default params
        ✔ pagination
        ✔ all filters
        ✔ invalid genre shold be considered as null
      post
        ✔ shold return a 201 status code
        ✔ rshould return a 401 status code
        ✔ shold return a 422 status code
    /movies/:id
      get
        ✔ should return 200 status code with a movie
        ✔ should return a 404 status code
      patch
        ✔ should return 200 status code
        ✔ should return 401 status code
        ✔ should return 422 status code
        ✔ should return a 404 status code
      delete
        ✔ should return a 200 status code
        ✔ should return 401 status code
        ✔ should return a 404 status code
    POST /movies/:id/characters
      ✔ should return a 201 status code
      ✔ should return 401 status code
      ✔ should return a 409 status code
      ✔ should return a 422 status code
      ✔ should return a 404 status code
    DELETE /movies/:idMovie/characters/:idCharacter
      ✔ should return a 200 status code
      ✔ should return a 401 status code
      ✔ should return a 404 status code - movie not found
      ✔ should return a 404 status code - character not found


  25 passing (2m)
```